### PR TITLE
Ensure that the singleton is destroyed between tests

### DIFF
--- a/unit_tests/test_charms_openstack_charm.py
+++ b/unit_tests/test_charms_openstack_charm.py
@@ -39,6 +39,8 @@ class BaseOpenStackCharmTest(utils.BaseTestCase):
 
     def tearDown(self):
         self.target = None
+        # if we've created a singleton on the module, also destroy that.
+        chm._singleton = None
         super(BaseOpenStackCharmTest, self).tearDown()
 
     def patch_target(self, attr, return_value=None, name=None, new=None):


### PR DESCRIPTION
This change ensures that the singleton in the charm.py for the
one-and-only charm instance is destroyed between tests.  Although not
currently causing a problem, it is a latent test bug.