### PR TITLE
Add Support for clustering units

### DIFF
--- a/charms_openstack/adapters.py
+++ b/charms_openstack/adapters.py
@@ -107,6 +107,23 @@ class PeerHARelationAdapter(OpenStackRelationAdapter):
 
     @staticmethod
     def local_network_split_addresses():
+        """Map of local units addresses for each address type
+
+           NOTE: This excludes private-address
+           @return dict of backends and networks for local unit e.g.
+               {'this_unit_admin_addr': {
+                    'backends': {
+                        'this_unit-1': 'this_unit_admin_addr'},
+                    'network': 'this_unit_admin_addr/admin_netmask'},
+                'this_unit_internal_addr': {
+                    'backends': {
+                        'this_unit-1': 'this_unit_internal_addr'},
+                    'network': 'this_unit_internal_addr/internal_netmask'},
+                'this_unit_public_addr': {
+                    'backends': {
+                        'this_unit-1': 'this_unit_public_addr'},
+                    'network': 'this_unit_public_addr/public_netmask'}}
+        """
         config = charmhelpers.core.hookenv.config()
         local_unit_name = APIConfigurationAdapter().local_unit_name
         _cluster_hosts = {}
@@ -122,6 +139,15 @@ class PeerHARelationAdapter(OpenStackRelationAdapter):
 
     @staticmethod
     def local_default_addresses():
+        """Map of local units private address
+
+           @return dict of private address info local unit e.g.
+               {'this_unit_private_addr': {
+                    'backends': {
+                        'this_unit-1': 'this_unit_private_addr'},
+                    'network': 'this_unit_private_addr/private_netmask'}}
+
+        """
         local_unit_name = APIConfigurationAdapter().local_unit_name
         local_address = APIConfigurationAdapter().local_address
         netmask = ch_ip.get_netmask_for_address(local_address)
@@ -132,8 +158,11 @@ class PeerHARelationAdapter(OpenStackRelationAdapter):
         return _local_map
 
     def add_network_split_addresses(self):
-        """Populate cluster_hosts with addresses of peers on a given network if
-        this node is also on that network"""
+        """Populate cluster_hosts with addresses of this unit and its
+           peers on each address type
+
+           @return None
+        """
         local_addresses = PeerHARelationAdapter.local_network_split_addresses()
         for addr_type in ADDRESS_TYPES:
             cfg_opt = 'os-{}-network'.format(addr_type)
@@ -145,7 +174,10 @@ class PeerHARelationAdapter(OpenStackRelationAdapter):
                     self.cluster_hosts[laddr]['backends'][_unit] = _laddr
 
     def add_default_addresses(self):
-        """Populate cluster_hosts with addresses supplied by private-address
+        """Populate cluster_hosts with private-address of this unit and its
+           peers
+
+           @return None
         """
         self.cluster_hosts[self.local_address] = \
             PeerHARelationAdapter.local_default_addresses()[self.local_address]

--- a/charms_openstack/adapters.py
+++ b/charms_openstack/adapters.py
@@ -402,11 +402,13 @@ class OpenStackRelationAdapters(object):
     def __init__(self, relations, options=ConfigurationAdapter, **kwargs):
         self._adapters.update(self.relation_adapters)
         self._relations = []
-#        if not charmhelpers.core.hookenv.relation_ids('cluster'):
-#            relation_value = {
-#            }
-#            setattr(self, 'cluster', relation_value)
-#            self._relations.append('cluster')
+        cluster_relid = charmhelpers.core.hookenv.relation_ids('cluster')[0]
+        if not charmhelpers.core.hookenv.related_units(relid=cluster_relid):
+            relation_value = {
+                'cluster_hosts': PeerHARelationAdapter.local_default_addresses(),
+            }
+            setattr(self, 'cluster', relation_value)
+            self._relations.append('cluster')
         for relation in relations:
             relation_name = relation.relation_name.replace('-', '_')
             try:

--- a/charms_openstack/adapters.py
+++ b/charms_openstack/adapters.py
@@ -344,7 +344,7 @@ class APIConfigurationAdapter(ConfigurationAdapter):
         @return True if user has requested ipv6 support otherwise False
         """
         if self.ipv6_mode:
-            addr = ch_ip.get_ipv6_addr(exc_list=[getattr(self, 'vip')])[0]
+            addr = ch_ip.get_ipv6_addr(exc_list=[self.vip])[0]
         else:
             addr = ch_utils.get_host_ip(
                 hookenv.unit_get('private-address'))

--- a/charms_openstack/adapters.py
+++ b/charms_openstack/adapters.py
@@ -405,7 +405,8 @@ class OpenStackRelationAdapters(object):
         cluster_relid = charmhelpers.core.hookenv.relation_ids('cluster')[0]
         if not charmhelpers.core.hookenv.related_units(relid=cluster_relid):
             relation_value = {
-                'cluster_hosts': PeerHARelationAdapter.local_default_addresses(),
+                'cluster_hosts':
+                    PeerHARelationAdapter.local_default_addresses(),
             }
             setattr(self, 'cluster', relation_value)
             self._relations.append('cluster')

--- a/charms_openstack/adapters.py
+++ b/charms_openstack/adapters.py
@@ -110,9 +110,7 @@ class PeerHARelationAdapter(OpenStackRelationAdapter):
         this node is also on that network"""
         for addr_type in ADDRESS_TYPES:
             cfg_opt = 'os-{}-network'.format(addr_type)
-            print(self.config.get(cfg_opt))
             laddr = ch_ip.get_address_in_network(self.config.get(cfg_opt))
-            print(laddr)
             if laddr:
                 netmask = ch_ip.get_netmask_for_address(laddr)
                 self.cluster_hosts[laddr] = {
@@ -383,6 +381,11 @@ class OpenStackRelationAdapters(object):
     def __init__(self, relations, options=ConfigurationAdapter, **kwargs):
         self._adapters.update(self.relation_adapters)
         self._relations = []
+#        if not charmhelpers.core.hookenv.relation_ids('cluster'):
+#            relation_value = {
+#            }
+#            setattr(self, 'cluster', relation_value)
+#            self._relations.append('cluster')
         for relation in relations:
             relation_name = relation.relation_name.replace('-', '_')
             try:

--- a/charms_openstack/adapters.py
+++ b/charms_openstack/adapters.py
@@ -434,6 +434,10 @@ class OpenStackRelationAdapters(object):
     def __init__(self, relations, options=ConfigurationAdapter, **kwargs):
         self._adapters.update(self.relation_adapters)
         self._relations = []
+        # LY: The cluster interface only gets initialised if there are more
+        # than one units of a cluster, however, a cluster of one unit is valid
+        # for the Openstack API charms. So, create and populate the 'cluster'
+        # namespace with data for a single unit if there are no peers.
         cluster_relid = charmhelpers.core.hookenv.relation_ids('cluster')[0]
         if not charmhelpers.core.hookenv.related_units(relid=cluster_relid):
             relation_value = {

--- a/charms_openstack/charm.py
+++ b/charms_openstack/charm.py
@@ -412,18 +412,17 @@ class OpenStackCharm(object):
         @return True if haproxy is fronting the service"""
         return 'haproxy' in self.ha_resources
 
+    def db_sync_done(self):
+        return hookenv.leader_get(attribute='db-sync-done')
+
     def db_sync(self):
         """Perform a database sync using the command defined in the
         self.sync_cmd attribute. The services defined in self.services are
         restarted after the database sync.
         """
-        sync_done = hookenv.leader_get(attribute='db-sync-done')
-        if not sync_done:
+        if not self.db_sync_done() and hookenv.is_leader():
             subprocess.check_call(self.sync_cmd)
             hookenv.leader_set({'db-sync-done': True})
-            # Restart services immediatly after db sync as
-            # render_domain_config needs a working system
-            self.restart_all()
 
     def configure_ha_resources(self, hacluster):
         """Inform the ha subordinate about each service it should manage. The

--- a/charms_openstack/charm.py
+++ b/charms_openstack/charm.py
@@ -5,12 +5,15 @@
 from __future__ import absolute_import
 
 import os
+import random
+import string
 import subprocess
 import contextlib
 import collections
 
 import six
 
+import charmhelpers.contrib.network.ip as ch_ip
 import charmhelpers.contrib.openstack.templating as os_templating
 import charmhelpers.contrib.openstack.utils as os_utils
 import charmhelpers.core.hookenv as hookenv
@@ -48,6 +51,9 @@ KNOWN_RELEASES = [
     'mitaka',
 ]
 
+VIP_KEY = "vip"
+CIDR_KEY = "vip_cidr"
+IFACE_KEY = "vip_iface"
 
 def get_charm_instance(release=None, *args, **kwargs):
     """Get an instance of the charm based on the release (or use the
@@ -428,42 +434,33 @@ class OpenStackCharm(object):
             'vips': self._add_ha_vips_config,
             'haproxy': self._add_ha_haproxy_config,
         }
-        self.resources = CRM()
         if not self.ha_resources:
             return
         for res_type in self.ha_resources:
-            RESOURCE_TYPES[res_type]()
-        # TODO Remove hardcoded multicast port
-        hacluster.bind_on(iface=self.config[IFACE_KEY], mcastport=4440)
-        hacluster.manage_resources(self.resources)
+           RESOURCE_TYPES[res_type](hacluster)
+        hacluster.bind_resources(iface=self.config[IFACE_KEY])
 
-    def _add_ha_vips_config(self):
+    def _add_ha_vips_config(self, hacluster):
         """Add a VirtualIP object for each user specified vip to self.resources
         """
-        for vip in self.config.get(VIP_KEY, []).split():
-            iface = (ip.get_iface_for_address(vip) or
+        for vip in self.config.get(VIP_KEY, '').split():
+            iface = (ch_ip.get_iface_for_address(vip) or
                      self.config(IFACE_KEY))
-            netmask = (ip.get_netmask_for_address(vip) or
+            netmask = (ch_ip.get_netmask_for_address(vip) or
                        self.config(CIDR_KEY))
             if iface is not None:
-                self.resources.add(
-                    ha.VirtualIP(
-                        self.name,
-                        vip,
-                        nic=iface,
-                        cidr=netmask,))
+                hacluster.add_vip(self.name, vip, iface, netmask)
 
-    def _add_ha_haproxy_config(self):
+    def _add_ha_haproxy_config(self, hacluster):
         """Add a InitService object for haproxy to self.resources
         """
-        self.resources.add(
-            ha.InitService(
-                self.name,
-                'haproxy',))
+        hacluster.add_init_service(self.name, 'haproxy')
 
     def set_haproxy_stat_password(self):
         """Set a stats password for accessing haproxy statistics"""
-        if not get_state('haproxy.stat.password'):
-            set_state('haproxy.stat.password', pwgen(32))
-
+        if not charms.reactive.bus.get_state('haproxy.stat.password'):
+            password = ''.join([
+                random.choice(string.ascii_letters + string.digits)
+                for n in range(32)])
+            charms.reactive.bus.set_state('haproxy.stat.password', password)
 

--- a/charms_openstack/charm.py
+++ b/charms_openstack/charm.py
@@ -55,6 +55,7 @@ VIP_KEY = "vip"
 CIDR_KEY = "vip_cidr"
 IFACE_KEY = "vip_iface"
 
+
 def get_charm_instance(release=None, *args, **kwargs):
     """Get an instance of the charm based on the release (or use the
     default if release is None).
@@ -229,7 +230,6 @@ class OpenStackCharm(object):
             self.adapters_instance = self.adapters_class(interfaces)
         self.set_haproxy_stat_password()
 
-
     def all_packages(self):
         """List of packages to be installed
 
@@ -396,8 +396,10 @@ class OpenStackCharm(object):
         :param interfaces: list of interface objects to render against
         """
         if not configs:
-            configs=self.full_restart_map().keys()
-        self.render_configs(configs, adapters_instance=self.adapters_class(interfaces))
+            configs = self.full_restart_map().keys()
+        self.render_configs(
+            configs,
+            adapters_instance=self.adapters_class(interfaces))
 
     def restart_all(self):
         """Restart all the services configured in the self.services[]
@@ -437,7 +439,7 @@ class OpenStackCharm(object):
         if not self.ha_resources:
             return
         for res_type in self.ha_resources:
-           RESOURCE_TYPES[res_type](hacluster)
+            RESOURCE_TYPES[res_type](hacluster)
         hacluster.bind_resources(iface=self.config[IFACE_KEY])
 
     def _add_ha_vips_config(self, hacluster):
@@ -463,4 +465,3 @@ class OpenStackCharm(object):
                 random.choice(string.ascii_letters + string.digits)
                 for n in range(32)])
             charms.reactive.bus.set_state('haproxy.stat.password', password)
-

--- a/charms_openstack/charm.py
+++ b/charms_openstack/charm.py
@@ -389,14 +389,15 @@ class OpenStackCharm(object):
                     target=conf,
                     context=adapters_instance)
 
-    def render_with_interfaces(self, interfaces):
+    def render_with_interfaces(self, interfaces, configs=None):
         """Render the configs using the interfaces passed; overrides any
         interfaces passed in the instance creation.
 
         :param interfaces: list of interface objects to render against
         """
-        self.render_all_configs(
-            adapters_instance=self.adapters_class(interfaces))
+        if not configs:
+            configs=self.full_restart_map().keys()
+        self.render_configs(configs, adapters_instance=self.adapters_class(interfaces))
 
     def restart_all(self):
         """Restart all the services configured in the self.services[]

--- a/unit_tests/test_charms_openstack_adapters.py
+++ b/unit_tests/test_charms_openstack_adapters.py
@@ -396,6 +396,12 @@ class MyOpenStackRelationAdapters(adapters.OpenStackRelationAdapters):
     }
 
 
+class MyConfigAdapter(adapters.ConfigurationAdapter):
+
+    def __init__(self, key1):
+        self.specialarg = key1
+
+
 class TestCustomOpenStackRelationAdapters(unittest.TestCase):
 
     def test_class(self):
@@ -411,5 +417,8 @@ class TestCustomOpenStackRelationAdapters(unittest.TestCase):
             amqp = FakeRabbitMQRelation()
             shared_db = FakeDatabaseRelation()
             mine = MyRelation()
-            a = MyOpenStackRelationAdapters([amqp, shared_db, mine])
+            a = MyOpenStackRelationAdapters([amqp, shared_db, mine],
+                                            options=MyConfigAdapter,
+                                            **{'key1': 'bob'})
             self.assertEqual(a.my_name.us, 'this-us')
+            self.assertEqual(a.options.specialarg, 'bob')

--- a/unit_tests/test_charms_openstack_charm.py
+++ b/unit_tests/test_charms_openstack_charm.py
@@ -242,7 +242,6 @@ class TestOpenStackCharm(BaseOpenStackCharmTest):
         self.leader_get.assert_called_once_with(attribute='db-sync-done')
         self.subprocess.check_call.assert_called_once_with(['a', 'cmd'])
         self.leader_set.assert_called_once_with({'db-sync-done': True})
-        self.restart_all.assert_called_once_with()
 
 
 class MyAdapter(object):


### PR DESCRIPTION
Apologies for the large diff.

I've added a PeerHARelationAdapter adapter which handles querying the IP addresses of its peers and compiling them into a dictionary that the haproxy template can then consume. It has two static methods for querying local unit data as these are used to populate the 'cluster' adapter namespace when the cluster relation has not yet been initialised.

The APIConfigurationAdapter extends the ConfigurationAdapter class and adds properties which are common across Openstack API charms.

I've also added methods for determining the restart_map and list of packages to be installed as these often need to be constructed dynamically at runtime rather than defined statically.