### PR TITLE
No cluster relation breaks PeerHARelationAdapter

### DIFF
--- a/charms_openstack/adapters.py
+++ b/charms_openstack/adapters.py
@@ -158,8 +158,9 @@ class PeerHARelationAdapter(OpenStackRelationAdapter):
                         'network': 'this_unit_private_addr/private_netmask'}}
         """
         relation_info = {}
-        cluster_relid = hookenv.relation_ids('cluster')[0]
-        if not hookenv.related_units(relid=cluster_relid):
+        cluster_relids = hookenv.relation_ids('cluster')
+        if (cluster_relids and not
+                hookenv.related_units(relid=cluster_relids[0])):
             relation_info = {
                 'cluster_hosts': self.local_default_addresses(),
             }

--- a/charms_openstack/adapters.py
+++ b/charms_openstack/adapters.py
@@ -158,12 +158,14 @@ class PeerHARelationAdapter(OpenStackRelationAdapter):
                         'network': 'this_unit_private_addr/private_netmask'}}
         """
         relation_info = {}
-        cluster_relids = hookenv.relation_ids('cluster')
-        if (cluster_relids and not
-                hookenv.related_units(relid=cluster_relids[0])):
-            relation_info = {
-                'cluster_hosts': self.local_default_addresses(),
-            }
+        try:
+            cluster_relid = hookenv.relation_ids('cluster')[0]
+            if not hookenv.related_units(relid=cluster_relid):
+                relation_info = {
+                    'cluster_hosts': self.local_default_addresses(),
+                }
+        except IndexError:
+            pass
         return relation_info
 
     def local_network_split_addresses(self):


### PR DESCRIPTION
If a charm does not have the cluster relation in its metadata.yaml then the
cluster relation does not exist but which leads to the  PeerHARelationAdapter
attempting to extract the first element of an empty list of relation ids.

The branch checks the relation_ids list before trying to extract from it which
closes #9