### PR TITLE
Add support for extra-bindings

### DIFF
--- a/charms_openstack/ip.py
+++ b/charms_openstack/ip.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 
 import charmhelpers.core.hookenv as hookenv
 import charmhelpers.contrib.network.ip as net_ip
-import charmhelpers.contrib.hahelpers.cluster
+import charmhelpers.contrib.hahelpers.cluster as cluster
 
 PUBLIC = 'public'
 INTERNAL = 'int'
@@ -11,17 +11,23 @@ ADMIN = 'admin'
 
 _ADDRESS_MAP = {
     PUBLIC: {
+        'binding': 'public',
         'config': 'os-public-network',
-        'fallback': 'public-address'
+        'fallback': 'public-address',
+        'override': 'os-public-hostname',
     },
     INTERNAL: {
+        'binding': 'internal',
         'config': 'os-internal-network',
-        'fallback': 'private-address'
+        'fallback': 'private-address',
+        'override': 'os-internal-hostname',
     },
     ADMIN: {
+        'binding': 'admin',
         'config': 'os-admin-network',
-        'fallback': 'private-address'
-    }
+        'fallback': 'private-address',
+        'override': 'os-admin-hostname',
+    },
 }
 
 
@@ -43,40 +49,95 @@ def canonical_url(endpoint_type=PUBLIC):
     return "{0}://{1}".format(scheme, address)
 
 
-def resolve_address(endpoint_type=PUBLIC):
-    """Return the address from the config() using endpoint_type to determine
-    which address to return.
+def _get_address_override(endpoint_type=PUBLIC):
+    """Returns any address overrides that the user has defined based on the
+    endpoint type.
 
-    It returns either the vip if the unit is clustered and there is no specific
-    config() item for the specified address type.
+    Note: this function allows for the service name to be inserted into the
+    address if the user specifies {service_name}.somehost.org.
 
-    If the unit is not clustered then it attempts to return either the ipv6 or
-    ipv4 address for the unit.
+    :param endpoint_type: the type of endpoint to retrieve the override
+                          value for.
+    :returns: any endpoint address or hostname that the user has overridden
+              or None if an override is not present.
+    """
+    override_key = _ADDRESS_MAP[endpoint_type]['override']
+    addr_override = hookenv.config(override_key)
+    if not addr_override:
+        return None
+    else:
+        return addr_override.format(service_name=hookenv.service_name())
+
+
+def resolve_address(endpoint_type=PUBLIC, override=True):
+    """Return unit address depending on net config.
+
+    If unit is clustered with vip(s) and has net splits defined, return vip on
+    correct network. If clustered with no nets defined, return primary vip.
+
+    If not clustered, return unit address ensuring address is on configured net
+    split if one is configured, or a Juju 2.0 extra-binding has been used.
+
+    :param endpoint_type: Network endpoing type
+    :param override: Accept hostname overrides or not
     """
     resolved_address = None
-    if charmhelpers.contrib.hahelpers.cluster.is_clustered():
-        if hookenv.config(_ADDRESS_MAP[endpoint_type]['config']) is None:
-            # Assume vip is simple and pass back directly
-            resolved_address = hookenv.config('vip')
-        else:
-            for vip in hookenv.config('vip').split():
-                if net_ip.is_address_in_network(
-                        hookenv.config(_ADDRESS_MAP[endpoint_type]['config']),
-                        vip):
+    if override:
+        resolved_address = _get_address_override(endpoint_type)
+        if resolved_address:
+            return resolved_address
+
+    vips = hookenv.config('vip')
+    if vips:
+        vips = vips.split()
+
+    net_type = _ADDRESS_MAP[endpoint_type]['config']
+    net_addr = hookenv.config(net_type)
+    net_fallback = _ADDRESS_MAP[endpoint_type]['fallback']
+    binding = _ADDRESS_MAP[endpoint_type]['binding']
+    clustered = cluster.is_clustered()
+
+    if clustered and vips:
+        if net_addr:
+            for vip in vips:
+                if net_ip.is_address_in_network(net_addr, vip):
                     resolved_address = vip
+                    break
+        else:
+            # NOTE: endeavour to check vips against network space
+            #       bindings
+            try:
+                bound_cidr = net_ip.resolve_network_cidr(
+                    hookenv.network_get_primary_address(binding)
+                )
+                for vip in vips:
+                    if net_ip.is_address_in_network(bound_cidr, vip):
+                        resolved_address = vip
+                        break
+            except NotImplementedError:
+                # If no net-splits configured and no support for extra
+                # bindings/network spaces so we expect a single vip
+                resolved_address = vips[0]
     else:
         if hookenv.config('prefer-ipv6'):
-            fallback_addr = net_ip.get_ipv6_addr(
-                exc_list=[hookenv.config('vip')])[0]
+            fallback_addr = net_ip.get_ipv6_addr(exc_list=vips)[0]
         else:
-            fallback_addr = hookenv.unit_get(
-                _ADDRESS_MAP[endpoint_type]['fallback'])
-        resolved_address = net_ip.get_address_in_network(
-            hookenv.config(_ADDRESS_MAP[endpoint_type]['config']),
-            fallback_addr)
+            fallback_addr = hookenv.unit_get(net_fallback)
+
+        if net_addr:
+            resolved_address = net_ip.get_address_in_network(net_addr,
+                                                             fallback_addr)
+        else:
+            # NOTE: only try to use extra bindings if legacy network
+            #       configuration is not in use
+            try:
+                resolved_address = hookenv.network_get_primary_address(binding)
+            except NotImplementedError:
+                resolved_address = fallback_addr
 
     if resolved_address is None:
-        raise ValueError('Unable to resolve a suitable IP address'
-                         ' based on charm state and configuration')
-    else:
-        return resolved_address
+        raise ValueError("Unable to resolve a suitable IP address based on "
+                         "charm state and configuration. (net_type=%s, "
+                         "clustered=%s)" % (net_type, clustered))
+
+    return resolved_address

--- a/unit_tests/test_charms_openstack_ip.py
+++ b/unit_tests/test_charms_openstack_ip.py
@@ -34,9 +34,9 @@ class TestCharmOpenStackIp(utils.BaseTestCase):
         self.resolve_address.assert_called_once_with(ip.INTERNAL)
 
     def test_resolve_address(self):
-        self.patch_object(ip.charmhelpers.contrib.hahelpers.cluster,
-                          'is_clustered')
+        self.patch_object(ip.cluster, 'is_clustered')
         self.patch_object(ip.hookenv, 'config')
+        self.patch_object(ip.hookenv, 'network_get_primary_address')
         self.patch_object(ip.net_ip, 'is_address_in_network')
         self.patch_object(ip.net_ip, 'get_ipv6_addr')
         self.patch_object(ip.hookenv, 'unit_get')
@@ -49,6 +49,7 @@ class TestCharmOpenStackIp(utils.BaseTestCase):
             'vip': 'vip-address',
             'prefer-ipv6': False,
             'os-public-network': 'the-public-network',
+            'os-public-hostname': None,
             'os-internal-network': 'the-internal-network',
             'os-admin-network': 'the-admin-network',
         }
@@ -59,6 +60,9 @@ class TestCharmOpenStackIp(utils.BaseTestCase):
 
         self.config.side_effect = fake_config
 
+        # Juju pre 2.0 behaviour where network-get is not implemented
+        self.network_get_primary_address.side_effect = NotImplementedError
+
         # first test, if not clustered, that the function uses unit_get() and
         # get_address_in_network to get a real address.
         # for the default PUBLIC endpoint
@@ -68,12 +72,15 @@ class TestCharmOpenStackIp(utils.BaseTestCase):
         addr = ip.resolve_address()
         self.assertEqual(addr, 'got-address')
         self.assertEqual(calls_list,
-                         [('prefer-ipv6',), ('os-public-network',)])
+                         [('os-public-hostname',),
+                          ('vip',),
+                          ('os-public-network',),
+                          ('prefer-ipv6',)])
         self.unit_get.assert_called_once_with('public-address')
         self.get_address_in_network.assert_called_once_with(
             'the-public-network', 'unit-get-address')
 
-        # second test: not clusted, prefer-ipv6 is True
+        # second test: not clustered, prefer-ipv6 is True
         _config['prefer-ipv6'] = True
         calls_list = []
         self.get_ipv6_addr.return_value = ['ipv6-addr']
@@ -88,23 +95,127 @@ class TestCharmOpenStackIp(utils.BaseTestCase):
         _config['os-public-network'] = None
         calls_list = []
         addr = ip.resolve_address()
-        self.assertEqual(calls_list, [('os-public-network',), ('vip',)])
+        self.assertEqual(calls_list, [('os-public-hostname',),
+                                      ('vip',),
+                                      ('os-public-network',)])
 
         # Fourth test: clustered, and config(...) returns not None
         _config['os-public-network'] = 'the-public-network'
         calls_list = []
         _config['vip'] = 'vip1 vip2'
-        self.is_address_in_network.return_value = (False, True)
+
+        def _fake_addr_in_net(address, vip):
+            return True if vip == 'vip2' else False
+
+        self.is_address_in_network.side_effect = _fake_addr_in_net
         addr = ip.resolve_address()
         self.assertEqual(calls_list, [
-            ('os-public-network',),
+            ('os-public-hostname',),
             ('vip',),
             ('os-public-network',),
-            ('os-public-network',)])
+        ])
         self.assertEqual(addr, 'vip2')
 
         # Finally resolved_address returns None -> ValueError()
         # allow vip to not be found:
         self.is_address_in_network.return_value = False
+        self.is_address_in_network.side_effect = None
+        with self.assertRaises(ValueError):
+            addr = ip.resolve_address()
+
+    def test_resolve_address_network_binding(self):
+        self.patch_object(ip.cluster, 'is_clustered')
+        self.patch_object(ip.hookenv, 'config')
+        self.patch_object(ip.hookenv, 'network_get_primary_address')
+        self.patch_object(ip.net_ip, 'is_address_in_network')
+        self.patch_object(ip.net_ip, 'get_ipv6_addr')
+        self.patch_object(ip.hookenv, 'unit_get')
+        self.patch_object(ip.net_ip, 'get_address_in_network')
+
+        # define a fake_config() that returns predictable results and remembers
+        # what it was called with.
+        calls_list = []
+        _config = {
+            'vip': 'vip1 vip2',
+            'prefer-ipv6': False,
+            'os-public-network': None,
+            'os-public-hostname': None,
+            'os-internal-network': None,
+            'os-admin-network': None,
+        }
+
+        def fake_config(*args):
+            calls_list.append(args)
+            return _config[args[0]]
+
+        self.config.side_effect = fake_config
+
+        # first test, if not clustered, that the function uses unit_get
+        # network_get_primary_address to get a real address.
+        # for the default PUBLIC endpoint
+        self.is_clustered.return_value = False
+        self.network_get_primary_address.return_value = 'got-address'
+        self.unit_get.return_value = 'unit-get-address'
+        addr = ip.resolve_address()
+        self.assertEqual(addr, 'got-address')
+        self.assertEqual(calls_list,
+                         [('os-public-hostname',),
+                          ('vip',),
+                          ('os-public-network',),
+                          ('prefer-ipv6',)])
+        self.unit_get.assert_called_once_with('public-address')
+        self.network_get_primary_address.assert_called_with(
+            'public'
+        )
+
+        # second test: not clustered, prefer-ipv6 is True, ensure
+        # that ipv6 address is fallback and network-get is still
+        # used to determine the public endpoint binding
+        _config['prefer-ipv6'] = True
+        calls_list = []
+        self.get_ipv6_addr.return_value = ['ipv6-addr']
+        self.get_address_in_network.reset_mock()
+        addr = ip.resolve_address()
+        self.get_ipv6_addr.assert_called_once_with(exc_list=['vip1', 'vip2'])
+        self.network_get_primary_address.assert_called_with(
+            'public'
+        )
+
+        def _fake_addr_in_net(address, vip):
+            return True if vip == 'vip2' else False
+
+        self.is_address_in_network.side_effect = _fake_addr_in_net
+
+        # Third test: clustered
+        self.is_clustered.return_value = True
+        calls_list = []
+        addr = ip.resolve_address()
+        self.assertEqual(calls_list, [('os-public-hostname',),
+                                      ('vip',),
+                                      ('os-public-network',)])
+        self.network_get_primary_address.assert_called_with(
+            'public'
+        )
+
+        # Fourth test: clustered, and config(...) returns not None
+        _config['os-public-network'] = 'the-public-network'
+        calls_list = []
+        _config['vip'] = 'vip1 vip2'
+
+        addr = ip.resolve_address()
+        self.assertEqual(calls_list, [
+            ('os-public-hostname',),
+            ('vip',),
+            ('os-public-network',),
+        ])
+        self.assertEqual(addr, 'vip2')
+        self.network_get_primary_address.assert_called_with(
+            'public'
+        )
+
+        # Finally resolved_address returns None -> ValueError()
+        # allow vip to not be found:
+        self.is_address_in_network.return_value = False
+        self.is_address_in_network.side_effect = None
         with self.assertRaises(ValueError):
             addr = ip.resolve_address()


### PR DESCRIPTION
Transfer updates from the charm-helpers openstack.ip module to
support use with Juju 2.0 extra-bindings via metadata.yaml.

Falls back to pre-2.0 behaviour if running on 1.25.5.